### PR TITLE
more descriptive error messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,7 +145,7 @@ const cropObject = (objectName, modelJSON, method = 'crop') => {
         imageURL = canvas.toDataURL()
         resolve(URLtoB64(imageURL))
       } catch (e) {
-        reject(`${ e } - image load error`)
+        reject(`Image load ${ e }`)
       }
     }
     img.src = data
@@ -232,11 +232,11 @@ const getPrediction = fileName => {
             fileName
           })
         } catch (e) {
-          reject(`error processing image - ${ e }`)
+          reject(`Image processing ${ e }`)
         }
       }
     } catch(e) {
-      reject(`error preprocessing image - ${ e }`)
+      reject(`Image pre-processing ${ e }`)
     }
   })  
 }
@@ -277,15 +277,17 @@ const processImage = async fileName => {
       removeObject(argv.remove, modelJSON)
     }
   } catch (e) {
-    console.error(`error processing image ${ fileName } - ${ e }`)
+    console.error(`Error processing '${ fileName }' - ${ e }`)
   }
 }
 
 const buildResponseMap = async (dirName, dirContents) => {
   return new Promise(async (resolve, reject) => {
     let responseMap = {}
+    let fileName
     try {
       for (let file of dirContents) {
+        fileName = file
         if (isImageFile(`${ dirName }/${ file }`)) {
           const response = await getPrediction(`${ dirName }/${ file }`)
           if (argv.contains && containsObject(argv.contains, response)) {
@@ -296,7 +298,7 @@ const buildResponseMap = async (dirName, dirContents) => {
         }
       }
     } catch (e) {
-      console.error(`error building response map - ${ e }`)
+      console.error(`Error encountered with '${ fileName }' while scanning '${ dirName }/' - ${ e }`)
     }
     resolve(responseMap)
   })
@@ -346,7 +348,7 @@ const processDirectory = async dirname => {
         removeObject(argv.remove, responseMap[file], true)
       }
     } catch (e) {
-      console.log(`error processing directory ${ dirName } - ${ e }`)
+      console.log(`Error processing directory '${ dirName }/' - ${ e }`)
     }
   })
 


### PR DESCRIPTION
This adds the 'offending' filename to error output for dir scans, along with a general refactor of the error message contents.

With these changes, if a scan is run on a directory containing a corrupt image file, like in the example given in the open issue, the output is
```
Scanning directory '/Users/nick/Code/MY_FORKS/magicat-1/sample-images'...

Error encountered with 'broken.jpg' while scanning 'sample-images/' - Image pre-processing Error: Could not find MIME for Buffer <null>
```

Running the tool on that file directly:
```
Error processing 'sample-images/broken.jpg' - Image pre-processing Error: Could not find MIME for Buffer <null>
```

Fixes #5 